### PR TITLE
chore: add missing extensions for PHP

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   // See https://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
   "recommendations": [
-    "redhat.php",
-    "redhat.php-debugger"
+    "bmewburn.vscode-intelephense-client",
+    "felixfbecker.php-debug"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

This pull request applies proper extensions for PHP

Part of https://issues.redhat.com/browse/CRW-3404

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/cakephp-ex?che-editor=che-incubator/che-code/insiders
